### PR TITLE
Feature/auth router

### DIFF
--- a/app/domain/db/db_dto.py
+++ b/app/domain/db/db_dto.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 
 
-class UpdateRequestDTO(BaseModel):
+class CrawlRequestDTO(BaseModel):
     auth: str
     year: int
     hakgi: int

--- a/app/domain/db/db_router.py
+++ b/app/domain/db/db_router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 from starlette.responses import JSONResponse
 
-from app.domain.db.db_dto import UpdateRequestDTO
+from app.domain.db.db_dto import CrawlRequestDTO
 from app.utils.env_util import CRAWL_AUTH
 from app.utils.StatusCode import StatusCode
 from app.utils.db_driver import update_jojik_and_classes
@@ -12,10 +12,10 @@ router = APIRouter(
 )
 
 @router.put(
-    "/update",
-    response_model=UpdateRequestDTO,
+    "/crawl",
+    response_model=CrawlRequestDTO,
     summary="Update Crawling Data / Resp. 안학룡")
-def update_crawling_data(item:  UpdateRequestDTO):
+def update_crawling_data(item:  CrawlRequestDTO):
     """
     크롤링 서버에서 받은 데이터를 DB에 업데이트하는 api
     """

--- a/app/domain/oauth/google/google_dto.py
+++ b/app/domain/oauth/google/google_dto.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class RefreshUserDTO(BaseModel):
+    refresh: str
+    email: str

--- a/app/domain/oauth/google/google_router.py
+++ b/app/domain/oauth/google/google_router.py
@@ -6,14 +6,15 @@ from app.utils.StatusCode import StatusCode
 from app.utils.db_driver import login_user, select_users_by_email
 
 from app.domain.oauth.google.google_service import get_google_token, get_google_token_info
-from app.domain.oauth.google.google_service import verify_google_token
+from app.domain.oauth.google.google_service import verify_google_token, refresh_google_token
 from app.domain.oauth.google.google_service import TOKEN_EXPIRE, TOKEN_ERROR
-
+from app.domain.oauth.google.google_dto import RefreshUserDTO
 
 router = APIRouter(
     prefix='/google',
     tags= ['oauth']
 )
+
 
 @router.get(
     "/login",
@@ -118,10 +119,54 @@ def auth_user(email: str, token: str = Depends(verify_google_token)):
     )
 
 
+@router.post(
+    "/refresh",
+    response_model=RefreshUserDTO,
+    summary="사용자의 access token 연장 / Resp. 안학룡"
+)
+def refresh_user(data: RefreshUserDTO, token: str = Depends(verify_google_token)):
+    """
+    사용자의 access token이 만료되어 재 발급 받아서 전달
+
+    :param data: {'email':str, 'refresh':str}
+    :param token: header에 access token 값을 전달
+    :return: {}
+    """
+
+    # ac_token 만료되지 않았거나, 정상적이지 않는 토큰을 반환했을 때
+    # if token != TOKEN_EXPIRE:
+    #     return JSONResponse(
+    #         status_code=StatusCode.HTTP_BAD_REQUEST,
+    #         content={'res': 'check your access token'},
+    #     )
+
+    user = select_users_by_email(data.email)
+
+    # 이상한 이메일 이거나, 보내온 데이터 확인.
+    if not user or user[2] != data.refresh:
+        return JSONResponse(
+            status_code=StatusCode.HTTP_BAD_REQUEST,
+            content={'res': 'invalid data'},
+        )
+
+    # 새로운 token 요청 및 사용자 업데이트
+    new_token = refresh_google_token(data.email, data.refresh)
+
+    if not new_token:
+        return JSONResponse(
+            status_code=StatusCode.HTTP_INTERNAL_SERVER_ERROR,
+            content={'res': 'Please try again in a few minutes.'}
+        )
+
+    return JSONResponse(
+        status_code=StatusCode.HTTP_OK,
+        content={
+            'res': 'ok!',
+            'access_token': new_token}
+    )
 
 
-
-@router.get("/callback",
-            summary="auth token 받기 위한 callback / 임시 콜백")
-def get_call_back(code: str):
-    return code
+# @router.get("/callback",
+#             summary="auth token 받기 위한 callback / 임시 콜백")
+# def get_call_back(code: str):
+#     return code

--- a/app/domain/oauth/google/google_router.py
+++ b/app/domain/oauth/google/google_router.py
@@ -1,17 +1,22 @@
-from fastapi import APIRouter
 import requests
-from starlette.responses import JSONResponse
 
+from fastapi import APIRouter
+from fastapi.params import Depends
+from starlette.responses import JSONResponse
+from fastapi.security import OAuth2PasswordBearer
 from app.utils.StatusCode import StatusCode
 from app.utils.db_driver import login_user
 from app.utils.env_util import GOOGLE_OAUTH_ID
 from app.utils.env_util import GOOGLE_OAUTH_SECRET
 from app.utils.env_util import GOOGLE_REDIRECT
 
+
 router = APIRouter(
     prefix='/google',
     tags= ['oauth']
 )
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/oauth/google/login")
 
 @router.get(
     "/login",
@@ -22,7 +27,7 @@ def login_with_google(auth_code: str):
     사용자가 준 구글 승인 코드를 사용 하여 로그인 수행.
 
     :param auth_code: 구글 승인 코드
-    :return: {"access_token": value, "user": value}
+    :return: {"access_token": value, "refresh_token": value, "user": value}
     """
 
     # access_token 요청
@@ -106,10 +111,24 @@ def login_with_google(auth_code: str):
         status_code=StatusCode.HTTP_OK,
         content={
             'res': 'ok!',
-            'access_token': token_info['access_token'],
+            'access_token': access_token,
+            'refresh_token': refresh_token,
             'user_email': user_email,
         }
     )
 
 
-# @router.get()
+@router.get(
+    "/auth",
+    summary="사용자의 access token 인증 / Resp. 안학룡"
+)
+def auth_user(token: str = Depends(oauth2_scheme)):
+    pass
+
+
+
+
+@router.get("/callback",
+            summary="auth token 받기 위한 callback / 임시 콜백")
+def get_call_back(code: str):
+    return code

--- a/app/domain/oauth/google/google_service.py
+++ b/app/domain/oauth/google/google_service.py
@@ -1,9 +1,11 @@
 import requests
+from fastapi import Header
 
 from app.utils.StatusCode import StatusCode
 from app.utils.env_util import GOOGLE_OAUTH_ID
 from app.utils.env_util import GOOGLE_OAUTH_SECRET
 from app.utils.env_util import GOOGLE_REDIRECT
+from typing import Optional
 
 def get_google_token(auth_code):
     """
@@ -62,3 +64,25 @@ def get_google_token_info(access_token):
         return None
 
     return {'email': result['email'], 'expires_in': int(result['expires_in'])}
+
+
+TOKEN_ERROR = 'error'
+TOKEN_EXPIRE = 'expire'
+
+def verify_google_token(auth: Optional[str] = Header(None)):
+    """
+    access token 을 검증 함.
+
+    :param auth: 사용자가 보낸 auth header
+    :return: str
+    """
+    if auth is None or not auth.startswith("Bearer "):
+        return TOKEN_ERROR
+
+    access_token = auth.split()[1]
+    token_info = get_google_token_info(access_token)
+
+    if not token_info:
+        return TOKEN_EXPIRE
+
+    return access_token

--- a/app/domain/oauth/google/google_service.py
+++ b/app/domain/oauth/google/google_service.py
@@ -68,24 +68,25 @@ def get_google_token_info(access_token):
 
 TOKEN_ERROR = 'error'
 TOKEN_EXPIRE = 'expire'
+TOKEN_OK = 'ok'
 
 def verify_google_token(auth: Optional[str] = Header(None)):
     """
     access token 을 검증 함.
 
     :param auth: 사용자가 보낸 auth header
-    :return: str
+    :return: [status, token]
     """
     if auth is None or not auth.startswith("Bearer "):
-        return TOKEN_ERROR
+        return [TOKEN_ERROR, None]
 
     access_token = auth.split()[1]
     token_info = get_google_token_info(access_token)
 
     if not token_info:
-        return TOKEN_EXPIRE
+        return [TOKEN_EXPIRE, access_token]
 
-    return access_token
+    return [TOKEN_OK, access_token]
 
 
 def refresh_google_token(email, refresh):

--- a/app/domain/oauth/google/google_service.py
+++ b/app/domain/oauth/google/google_service.py
@@ -1,0 +1,64 @@
+import requests
+
+from app.utils.StatusCode import StatusCode
+from app.utils.env_util import GOOGLE_OAUTH_ID
+from app.utils.env_util import GOOGLE_OAUTH_SECRET
+from app.utils.env_util import GOOGLE_REDIRECT
+
+def get_google_token(auth_code):
+    """
+    auth_code로 google에 access과 refresh token을 요청함.
+
+    :param auth_code: 사용자의 auth_code
+    :return: None, response {'access_token': str, 'refresh_token': str, ...}
+    """
+    uri = 'https://oauth2.googleapis.com/token'
+    data = {
+        'code': auth_code,
+        'client_id': GOOGLE_OAUTH_ID,
+        'client_secret': GOOGLE_OAUTH_SECRET,
+        'redirect_uri': GOOGLE_REDIRECT,
+        'grant_type': 'authorization_code',
+    }
+    res = requests.post(uri, data=data)
+
+    if res.status_code != StatusCode.HTTP_OK:
+        return None
+
+    result = res.json()
+
+    if 'access_token' not in result:
+        return None
+
+    if 'refresh_token' not in result:
+        return None
+
+    return result
+
+
+def get_google_token_info(access_token):
+    """
+    access token 을 통하여 현재 token의 정보를 가져옴.
+
+    :param access_token: access token
+    :return: None or {'email': str, 'expires_in: int}
+    """
+    uri = 'https://oauth2.googleapis.com/tokeninfo'
+    params = {
+        'access_token': access_token
+    }
+    res = requests.get(uri, params=params)
+
+    # 통신 확인
+    if res.status_code != 200:
+        return None
+
+    result = res.json()
+
+    if 'email' not in result:
+        return None
+
+    if 'expires_in' not in result:
+        return None
+
+    return {'email': result['email'], 'expires_in': int(result['expires_in'])}

--- a/app/utils/db_driver.py
+++ b/app/utils/db_driver.py
@@ -149,6 +149,12 @@ def select_jojik_name(gubun, year, hakgi):
 
         
 def select_class_by_idx(idx):
+    """
+    해당 구분(학과)의 개설 과목을 리턴 함.
+
+    :param idx: 해당 학과 ID
+    :return: 개설 과목들 [dict() ...]
+    """
     try:
         conn, cursor = get_conn_and_cursor()
 
@@ -180,8 +186,29 @@ def select_class_by_idx(idx):
         return []
 
 
+def select_users_by_email(email):
+    """
+    email 값을 이용하여 사용자 조회함.
+
+    :param email: 조회항 사용자
+    :return: [email, ac, rc]
+    """
+    try:
+        conn, cursor = get_conn_and_cursor()
+
+        sql_query = "SELECT * FROM users WHERE email = %s"
+        cursor.execute(sql_query, (email,))
+
+        data = cursor.fetchone()
+
+        close_conn_and_cursor(conn, cursor)
+
+        return data
+    except Error as e:
+        print(f"에러 발생 : {e}")
+        return []
+
+
 if __name__ == "__main__":
-    data = select_class_by_idx(12024201)
-    for d in data:
-        print(d)
+    select_users_by_email('@kyonggi.ac.kr')
     # select_jojik_name(1, None, None)

--- a/app/utils/db_driver.py
+++ b/app/utils/db_driver.py
@@ -1,7 +1,6 @@
 import mysql.connector
 
 from mysql.connector import Error
-from starlette.responses import JSONResponse
 from app.utils.env_util import DB_HOST
 from app.utils.env_util import DB_NAME
 from app.utils.env_util import DB_PASS
@@ -207,6 +206,28 @@ def select_users_by_email(email):
     except Error as e:
         print(f"에러 발생 : {e}")
         return []
+
+
+def update_user(email, token):
+    """
+    email 값을 이용하여 사용자의 ac token을 업데이트 함.
+
+    :param email: 업데이트할 사용자
+    :return: boolean / true : 정상, false : 비정상
+    """
+    try:
+        conn, cursor = get_conn_and_cursor()
+
+        sql_query = "UPDATE users SET ac_token = %s WHERE email = %s"
+        cursor.execute(sql_query, (token, email))
+        conn.commit()
+
+        close_conn_and_cursor(conn, cursor)
+
+        return True
+    except Error as e:
+        print(f"에러 발생 : {e}")
+        return False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* api 변경
  * 기존 DB crawling api가 /db/update -> /db/crawl 으로 수정하였습니다.
  * 사유 : update이라는 단어가 REST 원리를 따르지 않아서.
구현
  * 구글 로그인 리팩토링
    * 라우터 함수에서 많은 작업하는 게 관리하기 힘들어서 별도의 google_service로 로직을 이동 시켰습니다.
  * 사용자의 access token으로 사용자를 인증하는 API 구현 완료.
  * 사용자의 refresh token으로 새로운 access token을 발급받는 API 구현 완료.
* 테스트
  * 로컬에서 각 상황에 대하여 테스트 완료
  * 이메일과 access token 불일치한 요청에 대한 처리
  * access token이 만료되지 않는 상태에서 요청에 대한 처리
  * access token이 만료되었을 때 요청에 대한 처리  